### PR TITLE
Add default storage classes and more options

### DIFF
--- a/charts/templates/cluster_setup.yaml
+++ b/charts/templates/cluster_setup.yaml
@@ -240,6 +240,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -258,6 +259,7 @@ rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["update", "patch"]
+
 ---
 
 kind: ClusterRoleBinding
@@ -272,6 +274,7 @@ roleRef:
   kind: ClusterRole
   name: csi-gce-pd-snapshotter-role
   apiGroup: rbac.authorization.k8s.io
+
 ---
 
 kind: Role

--- a/charts/templates/controller.yaml
+++ b/charts/templates/controller.yaml
@@ -4,7 +4,7 @@ metadata:
   name: csi-gce-pd-controller
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.csiController.replicas }}
   selector:
     matchLabels:
       app: gcp-compute-persistent-disk-csi-driver
@@ -13,8 +13,26 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+{{- if .Values.csiController.runOnControlPlane }}
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+{{- end }}
       nodeSelector:
         kubernetes.io/os: linux
+{{- if .Values.csiController.runOnControlPlane }}
+        node-role.kubernetes.io/control-plane: ""
+{{- end }}
       serviceAccountName: csi-gce-pd-controller-sa
       priorityClassName: csi-gce-pd-controller
       containers:

--- a/charts/templates/node.yaml
+++ b/charts/templates/node.yaml
@@ -48,7 +48,7 @@ spec:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"
             - "--run-controller-service=false"
-            - "--kms-addr={{ .Values.csiNode.kmsAddress }}"
+            - "--kms-addr=kms.{{ .Values.csiNode.kmsNamespace | default .Release.Namespace }}:{{ .Values.csiNode.kmsPort }}"
           securityContext:
             privileged: true
           volumeMounts:

--- a/charts/templates/storageclass_default.yaml
+++ b/charts/templates/storageclass_default.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.createStorageClass }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: encrypted-storage
+parameters:
+  type: pd-standard
+provisioner: gcp.csi.confidential.cloud
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+{{- end }}

--- a/charts/templates/storageclass_default.yaml
+++ b/charts/templates/storageclass_default.yaml
@@ -4,7 +4,7 @@ kind: StorageClass
 metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
-  name: encrypted-storage
+  name: encrypted-rwo
 parameters:
   type: pd-standard
 provisioner: gcp.csi.confidential.cloud

--- a/charts/templates/storageclass_integrity.yaml
+++ b/charts/templates/storageclass_integrity.yaml
@@ -3,7 +3,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   annotations:
-  name: integrity-encrypted-storage
+  name: integrity-encrypted-rwo
 parameters:
   type: pd-ssd
   csi.storage.k8s.io/fstype: ext4-integrity

--- a/charts/templates/storageclass_integrity.yaml
+++ b/charts/templates/storageclass_integrity.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.createStorageClass }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+  name: integrity-encrypted-storage
+parameters:
+  type: pd-ssd
+  csi.storage.k8s.io/fstype: ext4-integrity
+provisioner: gcp.csi.confidential.cloud
+allowVolumeExpansion: false
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -21,8 +21,16 @@ image:
     pullPolicy: IfNotPresent
   gcepdDriver:
     repo: ghcr.io/edgelesssys/constellation/gcp-csi-driver
+    # CSI driver version is independent of Constellation releases
     tag: "v1.0.0"
     pullPolicy: IfNotPresent
 
+csiController:
+  replicas: 1
+  runOnControlPlane: true
+
 csiNode:
-  kmsAddress: "kms.kube-system:9000"
+  kmsPort: "9000"
+  kmsNamespace: "kube-system"
+
+createStorageClass: true


### PR DESCRIPTION
Make the driver a bit more configurable by letting users control whether or not to deploy the controller service on control-plane nodes and let them choose the number of replicas of the controller.
Also adds default storage classes to be deployed, if enabled.