### PR TITLE
Fix udev problems by not mounting udev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,51 +30,111 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04 as lib-builder
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    git gcc make autoconf automake autopoint pkg-config libtool gettext libssl-dev libdevmapper-dev \
-    libpopt-dev uuid-dev libsepol1-dev libjson-c-dev libssh-dev libblkid-dev tar libargon2-0-dev libpwquality-dev
+ARG BUILDPLATFORM
 
-# Build libcryptsetup from source so we can disable udev support
-RUN git clone -b v2.4.3 https://gitlab.com/cryptsetup/cryptsetup/ /cryptsetup
-WORKDIR /cryptsetup
-RUN ./autogen.sh
-# Disable udev support since this causes a deadlock on Kubernetes
-RUN CC=gcc CXX=g++ CFLAGS="-O1 -g" CXXFLAGS="-O1 -g" ./configure --enable-static --disable-udev
-RUN make
-
-FROM ubuntu:20.04 as builder
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libdevmapper-dev libjson-c-dev wget pkg-config build-essential
-RUN wget https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.18.4.linux-amd64.tar.gz
-ENV PATH=${PATH}:/usr/local/go/bin
-
-COPY --from=lib-builder /cryptsetup/.libs/libcryptsetup.so /usr/lib/x86_64-linux-gnu/libcryptsetup.so
-COPY --from=lib-builder /cryptsetup/lib/libcryptsetup.pc /usr/lib/x86_64-linux-gnu/pkgconfig/libcryptsetup.pc
-COPY --from=lib-builder /cryptsetup/lib/libcryptsetup.h  /usr/include/libcryptsetup.h
-
-RUN ln -s  /usr/lib/x86_64-linux-gnu/libcryptsetup.so  /usr/lib/x86_64-linux-gnu/libcryptsetup.so.12
+FROM --platform=$BUILDPLATFORM golang:1.18.4 as builder
 
 ARG STAGINGVERSION
 ARG TARGETPLATFORM
 
-#RUN apt-get update && apt-get install -y libcryptsetup-dev && apt-get autoremove -y && apt-get autoclean -y
 WORKDIR /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver
-COPY . .
+ADD . .
+RUN apt update --yes && apt install -y libcryptsetup-dev
 RUN GOARCH=$(echo $TARGETPLATFORM | cut -f2 -d '/') GCE_PD_CSI_STAGING_VERSION=$STAGINGVERSION make gce-pd-driver
 
-# MAD HACKS: Build a version first so we can take the scsi_id bin and put it somewhere else in our real build
-FROM k8s.gcr.io/build-image/debian-base:buster-v1.9.0 as mad-hack
-RUN clean-install udev
+# Start from Kubernetes Debian base.
+FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2 as debian
+# Install necessary dependencies
+# google_nvme_id script depends on the following packages: nvme-cli, xxd, bash
+RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd bash libcryptsetup-dev
 
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y util-linux e2fsprogs mount ca-certificates udev xfsprogs nvme-cli xxd libdevmapper-dev libjson-c-dev
+# Since we're leveraging apt to pull in dependencies, we use `gcr.io/distroless/base` because it includes glibc.
+FROM gcr.io/distroless/base-debian11 as distroless-base
 
+# The distroless amd64 image has a target triplet of x86_64
+FROM distroless-base AS distroless-amd64
+ENV LIB_DIR_PREFIX x86_64
+
+# The distroless arm64 image has a target triplet of aarch64
+FROM distroless-base AS distroless-arm64
+ENV LIB_DIR_PREFIX aarch64
+
+FROM distroless-$TARGETARCH
+
+# Copy necessary dependencies into distroless base.
 COPY --from=builder /go/src/sigs.k8s.io/gcp-compute-persistent-disk-csi-driver/bin/gce-pd-csi-driver /gce-pd-csi-driver
+COPY --from=debian /etc/mke2fs.conf /etc/mke2fs.conf
+COPY --from=debian /lib/udev/scsi_id /lib/udev_containerized/scsi_id
+COPY --from=debian /bin/udevadm /bin/udevadm
+COPY --from=debian /sbin/dmsetup /sbin/dmsetup
+COPY --from=debian /bin/mount /bin/mount
+COPY --from=debian /bin/umount /bin/umount
+COPY --from=debian /sbin/blkid /sbin/blkid
+COPY --from=debian /sbin/blockdev /sbin/blockdev
+COPY --from=debian /sbin/dumpe2fs /sbin/dumpe2fs
+COPY --from=debian /sbin/e* /sbin/
+COPY --from=debian /sbin/e2fsck /sbin/e2fsck
+COPY --from=debian /sbin/fsck /sbin/fsck
+COPY --from=debian /sbin/fsck* /sbin/
+COPY --from=debian /sbin/fsck.xfs /sbin/fsck.xfs
+COPY --from=debian /sbin/mke2fs /sbin/mke2fs
+COPY --from=debian /sbin/mkfs* /sbin/
+COPY --from=debian /sbin/resize2fs /sbin/resize2fs
+COPY --from=debian /sbin/xfs_repair /sbin/xfs_repair
+COPY --from=debian /usr/include/xfs /usr/include/xfs
+COPY --from=debian /usr/lib/xfsprogs/xfs* /usr/lib/xfsprogs/
+COPY --from=debian /usr/sbin/xfs* /usr/sbin/
+# Add dependencies for /lib/udev_containerized/google_nvme_id script
+COPY --from=debian /usr/sbin/nvme /usr/sbin/nvme
+COPY --from=debian /usr/bin/xxd /usr/bin/xxd
+COPY --from=debian /bin/bash /bin/bash
+COPY --from=debian /bin/date /bin/date
+COPY --from=debian /bin/grep /bin/grep
+COPY --from=debian /bin/sed /bin/sed
+COPY --from=debian /bin/ln /bin/ln
 
-COPY --from=lib-builder /cryptsetup/.libs/libcryptsetup.so /usr/lib/x86_64-linux-gnu/libcryptsetup.so
-RUN ln -s  /usr/lib/x86_64-linux-gnu/libcryptsetup.so  /usr/lib/x86_64-linux-gnu/libcryptsetup.so.12
-COPY --from=mad-hack /lib/udev/scsi_id /lib/udev_containerized/scsi_id
+# Copy shared libraries into distroless base.
+COPY --from=debian /lib/${LIB_DIR_PREFIX}-linux-gnu/libcom_err.so.2 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libdevmapper.so.1.02.1 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libe2p.so.2 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libext2fs.so.2 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libgcc_s.so.1 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre.so.3 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libreadline.so.8 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libselinux.so.1 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libtinfo.so.6 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libz.so.1 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libpthread.so.0 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/liblzma.so.5 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libdl.so.2 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libcryptsetup.so.12 \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/libcryptsetup.so \
+                   /lib/${LIB_DIR_PREFIX}-linux-gnu/
+
+COPY --from=debian /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libacl.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libattr.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicudata.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicui18n.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libicuuc.so.67 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libstdc++.so.6 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libblkid.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libmount.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libudev.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libuuid.so.1.3.0 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libuuid.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre2-8.so.0 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libpcre2-8.so.0.10.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libkmod.so.2 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libargon2.so.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libjson-c.so.5.1.0 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libjson-c.so.5 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/engines-1.1/afalg.so \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/engines-1.1/padlock.so \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libcrypto.so.1.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/libssl.so.1.1 \
+                   /usr/lib/${LIB_DIR_PREFIX}-linux-gnu/
+
+# Copy NVME support required script and rules into distroless base.
 COPY deploy/kubernetes/udev/google_nvme_id /lib/udev_containerized/google_nvme_id
 
 ENTRYPOINT ["/gce-pd-csi-driver"]

--- a/charts/templates/node.yaml
+++ b/charts/templates/node.yaml
@@ -61,14 +61,17 @@ spec:
               mountPath: /dev
             # The following mounts are required to trigger host udevadm from
             # container
-            - name: udev-rules-etc
-              mountPath: /etc/udev
-            - name: udev-rules-lib
-              mountPath: /lib/udev
-            - name: udev-socket
-              mountPath: /run/udev
-            - name: sys
-              mountPath: /sys
+            # But we don't want that, because it breaks cryptsetup
+            # Also, the task done by manually triggering udevadm are already
+            # performed by having the correct udev rules configured
+            # - name: udev-rules-etc
+            #   mountPath: /etc/udev
+            # - name: udev-rules-lib
+            #   mountPath: /lib/udev
+            # - name: udev-socket
+            #   mountPath: /run/udev
+            # - name: sys
+            #   mountPath: /sys
             - name: cryptsetup
               mountPath: /run/cryptsetup
       volumes:
@@ -90,18 +93,21 @@ spec:
             type: Directory
         # The following mounts are required to trigger host udevadm from
         # container
-        - name: udev-rules-etc
-          hostPath:
-            path: /etc/udev
-            type: Directory
-        - name: udev-rules-lib
-          hostPath:
-            path: /lib/udev
-            type: Directory
-        - name: udev-socket
-          hostPath:
-            path: /run/udev
-            type: Directory
+        # But we don't want that, because it breaks cryptsetup
+        # Also, the task done by manually triggering udevadm are already
+        # performed by having the correct udev rules configured
+        # - name: udev-rules-etc
+        #   hostPath:
+        #     path: /etc/udev
+        #     type: Directory
+        # - name: udev-rules-lib
+        #   hostPath:
+        #     path: /lib/udev
+        #     type: Directory
+        # - name: udev-socket
+        #   hostPath:
+        #     path: /run/udev
+        #     type: Directory
         - name: sys
           hostPath:
             path: /sys

--- a/deploy/kubernetes/udev/google_nvme_id
+++ b/deploy/kubernetes/udev/google_nvme_id
@@ -22,7 +22,6 @@ readonly nvme_cli_bin=/usr/sbin/nvme
 # Bash regex to parse device paths and controller identification
 readonly NAMESPACE_NUMBER_REGEX="/dev/nvme[[:digit:]]+n([[:digit:]]+).*"
 readonly PARTITION_NUMBER_REGEX="/dev/nvme[[:digit:]]+n[[:digit:]]+p([[:digit:]]+)"
-readonly PD_NVME_REGEX="sn[[:space:]]+:[[:space]]+nvme_card-pd"
 
 # Globals used to generate the symlinks for a PD-NVMe disk.  These are populated
 # by the identify_pd_disk function and exported for consumption by udev rules.
@@ -55,26 +54,26 @@ function err() {
 #######################################
 function get_namespace_device_name() {
   local nvme_json
-  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
+  nvme_json="$("${nvme_cli_bin}" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
   if [[ $? -ne 0 ]]; then
     return 1
   fi
 
-  if [[ -z "$nvme_json" ]]; then
+  if [[ -z ${nvme_json} ]]; then
     err "NVMe Vendor Extension disk information not present"
     return 1
   fi
 
   local device_name
-  device_name="$(echo "$nvme_json" | grep device_name | sed -e 's/.*"device_name":[  \t]*"\([a-zA-Z0-9_-]\+\)".*/\1/')"
+  device_name="$(echo "${nvme_json}" | grep device_name | sed -e 's/.*"device_name":[  \t]*"\([a-zA-Z0-9_-]\+\)".*/\1/')"
 
   # Error if our device name is empty
-  if [[ -z "$device_name" ]]; then
+  if [[ -z ${device_name} ]]; then
     err "Empty name"
     return 1
   fi
 
-  echo "$device_name"
+  echo "${device_name}"
   return 0
 }
 
@@ -92,13 +91,13 @@ function get_namespace_device_name() {
 function get_namespace_number() {
   local dev_path="$1"
   local namespace_number
-  if [[ "$dev_path" =~ $NAMESPACE_NUMBER_REGEX ]]; then
+  if [[ ${dev_path} =~ ${NAMESPACE_NUMBER_REGEX} ]]; then
     namespace_number="${BASH_REMATCH[1]}"
   else
     return 1
   fi
 
-  echo "$namespace_number"
+  echo "${namespace_number}"
   return 0
 }
 
@@ -115,9 +114,9 @@ function get_namespace_number() {
 function get_partition_number() {
   local dev_path="$1"
   local partition_number
-  if [[ "$dev_path" =~ $PARTITION_NUMBER_REGEX ]]; then
+  if [[ ${dev_path} =~ ${PARTITION_NUMBER_REGEX} ]]; then
     partition_number="${BASH_REMATCH[1]}"
-    echo "$partition_number"
+    echo "${partition_number}"
   else
     echo ''
   fi
@@ -134,12 +133,13 @@ function get_partition_number() {
 #######################################
 function gen_symlink() {
   local dev_path="$1"
-  local partition_number="$(get_partition_number "$dev_path")"
+  local partition_number
+  partition_number="$(get_partition_number "${dev_path}")"
 
-  if [[ -n "$partition_number" ]]; then
-    ln -s "$dev_path" /dev/disk/by-id/google-"$ID_SERIAL_SHORT"-part"$partition_number" > /dev/null 2>&1
+  if [[ -n ${partition_number} ]]; then
+    ln -s "${dev_path}" /dev/disk/by-id/google-"${ID_SERIAL_SHORT}"-part"${partition_number}" > /dev/null 2>&1
   else
-    ln -s "$dev_path" /dev/disk/by-id/google-"$ID_SERIAL_SHORT" > /dev/null 2>&1
+    ln -s "${dev_path}" /dev/disk/by-id/google-"${ID_SERIAL_SHORT}" > /dev/null 2>&1
   fi
 
   return 0
@@ -157,12 +157,12 @@ function gen_symlink() {
 function identify_pd_disk() {
   local dev_path="$1"
   local dev_name
-  dev_name="$(get_namespace_device_name "$dev_path")"
+  dev_name="$(get_namespace_device_name "${dev_path}")"
   if [[ $? -ne 0 ]]; then
     return 1
   fi
 
-  ID_SERIAL_SHORT="$dev_name"
+  ID_SERIAL_SHORT="${dev_name}"
   ID_SERIAL="Google_PersistentDisk_${ID_SERIAL_SHORT}"
   return 0
 }
@@ -181,26 +181,28 @@ function main() {
   local device_path=''
 
   while getopts :d:sh flag; do
-    case "$flag" in
-      d) device_path="$OPTARG";;
-      s) opt_gen_symlink='true';;
-      h) print_help_message
-         return 0
-         ;;
-      :) echo "Invalid option: ${OPTARG} requires an argument" 1>&2
-         return 1
-         ;;
-      *) return 1
+    case "${flag}" in
+    d) device_path="${OPTARG}" ;;
+    s) opt_gen_symlink='true' ;;
+    h)
+      print_help_message
+      return 0
+      ;;
+    :)
+      echo "Invalid option: ${OPTARG} requires an argument" 1>&2
+      return 1
+      ;;
+    *) return 1 ;;
     esac
   done
 
-  if [[ -z "$device_path" ]]; then
+  if [[ -z ${device_path} ]]; then
     echo "Device path (-d) argument required. Use -h for full usage." 1>&2
     exit 1
   fi
 
   # Ensure the nvme-cli command is installed
-  command -v "$nvme_cli_bin" > /dev/null 2>&1
+  command -v "${nvme_cli_bin}" > /dev/null 2>&1
   if [[ $? -ne 0 ]]; then
     err "The nvme utility (/usr/sbin/nvme) was not found. You may need to run \
 with sudo or install nvme-cli."
@@ -208,7 +210,7 @@ with sudo or install nvme-cli."
   fi
 
   # Ensure the passed device is actually an NVMe device
-  "$nvme_cli_bin" id-ctrl "$device_path" &>/dev/null
+  "${nvme_cli_bin}" id-ctrl "${device_path}" &> /dev/null
   if [[ $? -ne 0 ]]; then
     err "Passed device was not an NVMe device.  (You may need to run this \
 script as root/with sudo)."
@@ -217,22 +219,22 @@ script as root/with sudo)."
 
   # Detect the type of attached nvme device
   local controller_id
-  controller_id=$("$nvme_cli_bin" id-ctrl "$device_path")
-  if [[ ! "$controller_id" =~ nvme_card-pd ]] ; then
+  controller_id=$("${nvme_cli_bin}" id-ctrl "${device_path}")
+  if [[ ! ${controller_id} =~ nvme_card-pd ]]; then
     err "Device is not a PD-NVMe device"
     return 1
   fi
 
   # Fill the global variables for the id command for the given disk type
   # Error messages will be printed closer to error, no need to reprint here
-  identify_pd_disk "$device_path"
+  identify_pd_disk "${device_path}"
   if [[ $? -ne 0 ]]; then
     return $?
   fi
 
   # Gen symlinks or print out the globals set by the identify command
-  if [[ "$opt_gen_symlink" == 'true' ]]; then
-    gen_symlink "$device_path"
+  if [[ ${opt_gen_symlink} == 'true' ]]; then
+    gen_symlink "${device_path}"
   else
     # These will be consumed by udev
     echo "ID_SERIAL_SHORT=${ID_SERIAL_SHORT}"

--- a/pkg/gce-pd-csi-driver/node.go
+++ b/pkg/gce-pd-csi-driver/node.go
@@ -338,14 +338,19 @@ func (ns *GCENodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStage
 
 	// [Edgeless] Part 2.5: Map the device as a crypt device, creating a new LUKS partition if needed
 	fstype, integrity := cryptmapper.IsIntegrityFS(fstype)
+	if integrity {
+		klog.V(4).Infof("Integrity protected FS requested. Preparing to wipe device...")
+	}
 	devicePathReal, err := ns.evalSymLinks(devicePath)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("could not evaluate device path for device %q: %v", devicePath, err))
 	}
+	klog.V(4).Infof("Creating LUKS2 device on %s", devicePathReal)
 	devicePath, err = ns.CryptMapper.OpenCryptDevice(ctx, devicePathReal, volumeKey.Name, integrity)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("NodeStageVolume failed on volume %v to %s, open crypt device failed (%v)", devicePath, stagingTargetPath, err))
 	}
+	klog.V(4).Infof("Successfully created LUKS2 device on %s", devicePath)
 
 	// Part 3: Mount device to stagingTargetPath
 	if blk := volumeCapability.GetBlock(); blk != nil {


### PR DESCRIPTION
Fixes udev problems encountered by using cryptsetup installed from package by not mounting udev to the container.
The Dockerfile is now based on upstream again (with the slight difference that we use a more up to date version of debian as a base image).

I have also swapped the `google_nvme_id` script with the one from the Constellation repo to fix potential problems and have a properly linted script.

Also added some extra logging 
