### PR TITLE
Update registry and pin image by hash

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,23 +1,23 @@
 image:
   csiProvisioner:
-    repo: k8s.gcr.io/sig-storage/csi-provisioner
-    tag: "v3.1.1"
+    repo: registry.k8s.io/sig-storage/csi-provisioner
+    tag: "v3.1.1@sha256:76f5b1c63bfbbe3d17819e675ca22ff7a7a74ccdbb509c0117c2133a63c5e950"
     pullPolicy: IfNotPresent
   csiAttacher:
-    repo: k8s.gcr.io/sig-storage/csi-attacher
-    tag: "v3.5.0"
+    repo: registry.k8s.io/sig-storage/csi-attacher
+    tag: "v3.5.0@sha256:dd245051317e957423bc3e2aecddf56c745bd6714920f0dc108e505f5afb3472"
     pullPolicy: IfNotPresent
   csiResizer:
-    repo: k8s.gcr.io/sig-storage/csi-resizer
-    tag: "v1.5.0"
+    repo: registry.k8s.io/sig-storage/csi-resizer
+    tag: "v1.5.0@sha256:8f7520bd957e7151fda9886eb5090739439811aeec5ddffb50ad7c8191548d97"
     pullPolicy: IfNotPresent
   csiSnapshotter:
-    repo: k8s.gcr.io/sig-storage/csi-snapshotter
-    tag: "v6.0.1"
+    repo: registry.k8s.io/sig-storage/csi-snapshotter
+    tag: "v6.0.1@sha256:ad16874e2140256a809cada2b4ac3d931d5b73b0bee23ed0f8d60bdd778cfec2"
     pullPolicy: IfNotPresent
   csiNodeRegistrar:
-    repo: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.5.1"
+    repo: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    tag: "v2.5.1@sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4"
     pullPolicy: IfNotPresent
   gcepdDriver:
     repo: ghcr.io/edgelesssys/constellation/gcp-csi-driver


### PR DESCRIPTION
* Update registries from deprecated `k8s.gcr.io` to `registry.k8s.io`
* Add hash pinning for images